### PR TITLE
Add release workflow to publish Linux binary on tag push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: conanio/gcc11
+      options: --user root
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Upgrade Conan
+        run: pip install conan==1.65.0
+
       - name: Create Build Folder
         run: mkdir build
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: '3.12'
       - name: Install Conan
         run: pip install conan==1.60.0 && conan --version
       - name: Create Build Folder

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,15 +1,17 @@
 name: C/C++
 
-on: [push]
+on:
+  push:
+  workflow_dispatch:
 
 jobs:
   test:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.7
       - name: Install Conan

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,25 +7,22 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    container:
+      image: conanio/gcc11
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.12'
-      - name: Install Conan
-        run: pip install conan==1.60.0 && conan --version
+
       - name: Create Build Folder
         run: mkdir build
-      - name: Install CMake
-        run: conan install cmake/3.16.4@ -g=virtualrunenv
-        working-directory: ./build
+
       - name: Build
         run: conan install -s compiler.libcxx=libstdc++ --build=missing .. && cmake .. && cmake --build ./ --target all --parallel
         working-directory: ./build
+
       - name: Test
         run: ctest --parallel
         working-directory: ./build
+
       - name: Exec
         run: ./build/src/cli_client --help

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Upgrade Conan
+        run: pip install conan==1.65.0
+
       - name: Create Build Folder
         run: mkdir build
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-22.04
     container:
       image: conanio/gcc11
+      options: --user root
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,73 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install Conan
+        run: pip install conan==1.60.0 && conan --version
+
+      - name: Create Build Folder
+        run: mkdir build
+
+      - name: Install CMake
+        run: conan install cmake/3.16.4@ -g=virtualrunenv
+        working-directory: ./build
+
+      - name: Build
+        run: |
+          conan install -s compiler.libcxx=libstdc++ --build=missing .. && \
+          cmake .. -DCMAKE_BUILD_TYPE=Release && \
+          cmake --build ./ --target cli_client --parallel
+        working-directory: ./build
+
+      - name: Strip binary
+        run: strip build/src/cli_client
+
+      - name: Package binary
+        run: |
+          tar czf cli_client-linux-x86_64-${{ github.ref_name }}.tar.gz \
+            -C build/src cli_client
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-binary
+          path: cli_client-linux-x86_64-${{ github.ref_name }}.tar.gz
+
+  release:
+    runs-on: ubuntu-22.04
+    needs: build
+
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: release-binary
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          gh release create ${{ github.ref_name }} \
+            cli_client-linux-x86_64-${{ github.ref_name }}.tar.gz \
+            --title "${{ github.ref_name }}" \
+            --generate-notes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.12'
 
       - name: Install Conan
         run: pip install conan==1.60.0 && conan --version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,24 +12,14 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-22.04
+    container:
+      image: conanio/gcc11
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.12'
-
-      - name: Install Conan
-        run: pip install conan==1.60.0 && conan --version
-
       - name: Create Build Folder
         run: mkdir build
-
-      - name: Install CMake
-        run: conan install cmake/3.16.4@ -g=virtualrunenv
-        working-directory: ./build
 
       - name: Build
         run: |


### PR DESCRIPTION
- Add release.yml: builds cli_client in Release mode on ubuntu-22.04, strips and packages the binary as a tar.gz, and creates a GitHub Release
- Update ci.yml: bump actions/checkout and actions/setup-python to v4, add workflow_dispatch trigger